### PR TITLE
Fix/issue 101 67 153

### DIFF
--- a/contracts/lending/Lens/CompoundLens.sol
+++ b/contracts/lending/Lens/CompoundLens.sol
@@ -14,7 +14,7 @@ interface ComptrollerLensInterface {
         address,
         CToken,
         CToken
-    ) external view returns (uint, uint, uint, uint);
+    ) external view returns (uint, uint, uint, uint,uint);
     function getAssetsIn(address) external view returns (CToken[] memory);
     function borrowCaps(address) external view returns (uint);
 }
@@ -222,7 +222,8 @@ contract CompoundLens {
             uint errorCode,
             uint liquidity,
             uint shortfall,
-            uint badDebt
+            uint badDebt,
+            
         ) = comptroller.getAccountLiquidityIsolate(account, collateral, borrow);
         require(errorCode == 0);
 


### PR DESCRIPTION
we did several things to improve bad debt liquidations:

1) when not in bad debt, if liquidation is full (not partial) and there is not enough collateral to pay for incentives, liquidator will get all collateral. It will still be profitable (but total profit will be less than liquidation incentives because there is not enough collateral to pay for them)

2) when in bad debt and above some ltv (new parameter called "ltvMinPartialLiquidations"), partial liquidations are allowed. They use liquidation incentives and profit is not clipped by the vault.

3) our specific "bad debt liquidations" (liquidate x%, get x% of collateral) can be enabled at some ltv threshold ("ltvMinBadDebtLiquidations"). It should be arount 98%